### PR TITLE
Callout - move from individual props to a single validated type prop

### DIFF
--- a/src/components/VltCallout.vue
+++ b/src/components/VltCallout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="Vlt-callout" :class="getClassObject()">
+  <div class="Vlt-callout" :class="getClassArray()">
     <i></i>
     <div class="Vlt-callout__content">
       <slot></slot>
@@ -8,26 +8,23 @@
 </template>
 
 <script>
+const VALID_TYPES = ['critical', 'good', 'tip', 'shoutout', 'warning'];
+
 export default {
   name: 'VltCallout',
 
   props: {
-    critical: Boolean,
-    good: Boolean,
-    tip: Boolean,
-    shoutout: Boolean,
-    warning: Boolean,
+    type: {
+      type: String,
+      required: true,
+      validator: (val) => VALID_TYPES.includes(val),
+    },
   },
 
   methods: {
-    getClassObject() {
-      return {
-        'Vlt-callout--critical': this.critical,
-        'Vlt-callout--good': this.good,
-        'Vlt-callout--tip': this.tip,
-        'Vlt-callout--shoutout': this.shoutout,
-        'Vlt-callout--warning': this.warning,
-      };
+    getClassArray() {
+      return VALID_TYPES.filter((type) => type === this.type)
+        .map((type) => `Vlt-callout--${type}`);
     },
   },
 };

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -30,11 +30,11 @@
       <div class="Vlt-col">
         <h4>Callout</h4>
         <div>
-          <vlt-callout critical>A critical callout</vlt-callout>
-          <vlt-callout good>A good callout</vlt-callout>
-          <vlt-callout tip>A tip callout</vlt-callout>
-          <vlt-callout shoutout>A shoutout callout</vlt-callout>
-          <vlt-callout warning>A warning callout</vlt-callout>
+          <vlt-callout type="critical">A critical callout</vlt-callout>
+          <vlt-callout type="good">A good callout</vlt-callout>
+          <vlt-callout type="tip">A tip callout</vlt-callout>
+          <vlt-callout type="shoutout">A shoutout callout</vlt-callout>
+          <vlt-callout type="warning">A warning callout</vlt-callout>
         </div>
       </div>
     </div>

--- a/src/demo/data.js
+++ b/src/demo/data.js
@@ -36,11 +36,7 @@ const Components = [
     html: 'vlt-callout',
     icon: 'shout',
     propertyRows: [
-      { property: 'critical', type: 'Boolean' },
-      { property: 'good', type: 'Boolean' },
-      { property: 'tip', type: 'Boolean' },
-      { property: 'shoutout', type: 'Boolean' },
-      { property: 'warning', type: 'Boolean' },
+      { property: 'type', type: 'String' },
     ],
     code: '<vlt-callout>Callout text</vlt-callout>',
   },


### PR DESCRIPTION
My code ended up having to do the following as i was using the callout for results of a server call. It seems nicer and can be validated if it's one single type property. Open to opinion though.

```
<vlt-callout
    v-bind:good="resultType === 'good'"
    v-bind:critical="resultType === 'critical'"
>
    {{ resultText }}
</vlt-callout>
```

after this PR it would be
```
<vlt-callout v-bind:type="resultType">
    {{ resultText }}
</vlt-callout>
```
