### PR TITLE
VltFlash: Stop emitting a dismissed event when visible is set to false

### DIFF
--- a/src/components/VltFlash.vue
+++ b/src/components/VltFlash.vue
@@ -52,11 +52,14 @@ export default {
 
   watch: {
     flashVisible(value) {
-      if (value && this.bottom) {
+      if (!value) {
+        return;
+      }
+      if (this.bottom) {
         countBottom += 1;
         this.index = countBottom;
         this.styleObject.bottom = `${(this.index * 70) - 50}px`;
-      } else if (value) {
+      } else {
         countTop += 1;
         this.index = countTop;
         this.styleObject.top = `${(this.index * 70) - 50}px`;
@@ -64,14 +67,12 @@ export default {
     },
 
     visible(value) {
+      if (!value) {
+        return;
+      }
       this.flashVisible = value;
-
-      const self = this;
-
       if (!this.dismissable) {
-        setTimeout(() => {
-          self.dismiss();
-        }, this.timeout);
+        setTimeout(this.dismiss, this.timeout);
       }
     },
   },


### PR DESCRIPTION
When setting `visible` prop to `false` a setTimeout is set for the dismiss event. This means that if you set `visible` prop to false when you get the callback then you start a feedback loop.

Also:
* Remove `self` reference
* Simpler `flashVisible` logic