### PR TITLE
Dropdown improvements

### DIFF
--- a/src/components/VltDropdown.vue
+++ b/src/components/VltDropdown.vue
@@ -2,7 +2,6 @@
    <div class="Vlt-dropdown" :class="{ 'Vlt-dropdown--expanded' : expanded }">
     <button
       :class="getButtonClass()"
-      :style="getButtonStyle()"
       @click="toggleDropdown($event)"
     >
       <span v-if="label && (!hideLabel || !selectedOption)">
@@ -40,7 +39,6 @@ export default {
       default: false,
     },
     label: String,
-    minWidth: String,
     options: Array,
     property: String,
     selected: {
@@ -66,13 +64,8 @@ export default {
     getButtonClass() {
       return {
         'Vlt-dropdown__btn': true,
-        'min-width-button': this.minWidth,
         'Vlt-dropdown__btn--app': this.app,
       };
-    },
-
-    getButtonStyle() {
-      return this.minWidth ? { 'min-width': this.minWidth } : {};
     },
 
     toggleDropdown(event) {
@@ -114,10 +107,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.min-width-button {
-  display: flex;
-  justify-content: space-between;
-}
-</style>

--- a/src/demo/Demo.vue
+++ b/src/demo/Demo.vue
@@ -70,11 +70,6 @@
             label="app styling"
             :options="['cat', 'dog', 'hamster', 'rabbit']"
           />
-          <vlt-dropdown
-            showSelection
-            minWidth="200px"
-            :options="['minWidth', 'dog', 'hamster', 'rabbit']"
-          />
         </div>
       </div>
     </div>

--- a/src/demo/data.js
+++ b/src/demo/data.js
@@ -64,7 +64,6 @@ const Components = [
       { property: 'app', type: 'Boolean', default: false },
       { property: 'id', type: 'String' },
       { property: 'label', type: 'String' },
-      { property: 'minWidth', type: 'String' },
       { property: 'selected', type: 'String', default: 'the first option in the options array' },
       { property: 'show-selection', type: 'Boolean' },
     ],


### PR DESCRIPTION
* Added `minWidth` prop as an attempt to stop the control jumping around if the options are different length
* Added `app` prop to get a square border
* Changed `selected` PropTypes to an array of types - threw error in jest test with `||`
* Removed auto scrolling as it broke our app
* Added options as a watch() as it broke when options were loaded in async on the `mounted()` callback of the parent
* Updated demo and docs

**Without minWidth**

![dropdown](https://user-images.githubusercontent.com/853893/46022288-3aff1800-c0da-11e8-95c9-e55afff98c6f.gif)

**With minWidth**
![min-width](https://user-images.githubusercontent.com/853893/46022367-5ec25e00-c0da-11e8-85f9-7d1b223098fb.gif)
