### PR TITLE
Fix - Removed static class and class from vlt button

### DIFF
--- a/src/components/VltButton.vue
+++ b/src/components/VltButton.vue
@@ -13,7 +13,7 @@
         !(props.secondary || props.primary || props.destructive || props.quaternary),
       'Vlt-btn--small': props.small,
       'Vlt-btn--large': props.large,
-    }, data.staticClass, data.class
+    }
     ]"
     v-on="listeners"
   >


### PR DESCRIPTION
Hey, 

I've removed these two properties as they were blowing up a few of our tests because the data isn't defined in the component.

Maybe this isn't the correct fix if they served another purpose? please let me know :)