### PR TITLE
apply  to global object, rather than Vue.prototype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vonagevolta/vue",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vonagevolta/vue",
   "description": "Vue.js components for Vonage Volta",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "scripts": {
     "ci": "npm run lint && npm test",
     "dev": "webpack-dev-server",

--- a/src/components/flash/VltFlash.vue
+++ b/src/components/flash/VltFlash.vue
@@ -11,7 +11,7 @@
 <script>
   import Vue from 'vue';
 
-  Vue.prototype.$FlashBus = new Vue();
+  global.$FlashBus = new Vue();
 
   const VALID_TYPES = ['critical', 'good', 'shoutout', 'warning'];
 
@@ -103,9 +103,9 @@
         this.flashVisible = false;
         this.$emit('dismissed');
         if (this.bottom) {
-          this.$FlashBus.$emit('bottom-dismissed', this.index);
+          global.$FlashBus.$emit('bottom-dismissed', this.index);
         } else {
-          this.$FlashBus.$emit('top-dismissed', this.index);
+          global.$FlashBus.$emit('top-dismissed', this.index);
         }
       },
     },
@@ -114,7 +114,7 @@
       const self = this;
 
       if (this.bottom) {
-        this.$FlashBus.$on('bottom-dismissed', index => {
+        global.$FlashBus.$on('bottom-dismissed', index => {
           if (self.flashVisible) {
             if (index < self.index) {
               self.index -= 1;
@@ -123,7 +123,7 @@
           }
         });
       } else {
-        this.$FlashBus.$on('top-dismissed', index => {
+        global.$FlashBus.$on('top-dismissed', index => {
           if (self.flashVisible) {
             if (index < self.index) {
               self.index -= 1;


### PR DESCRIPTION
Update where we apply the `$FlashBus` object so we don't use the Vue instance prototype. We found this issue while running the unit tests in the Customer Dashboard after upgrade the node modules.